### PR TITLE
Fix default model selection

### DIFF
--- a/olaw/views/ui.py
+++ b/olaw/views/ui.py
@@ -18,7 +18,7 @@ def get_root():
 
     # Pick a default model
     if "openai/gpt-4-turbo-preview" in available_models:
-        default_model = "openai/gpt-4-turbo"
+        default_model = "openai/gpt-4-turbo-preview"
 
     if not default_model:
         for model in available_models:


### PR DESCRIPTION
## Summary
- fix the default model name in the UI template when GPT‑4 turbo preview is available

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686413f1a7e0832898e7e6be4009911b